### PR TITLE
Cms 7650: Allow placing of additional head content on pages/templates directly after <head> tag

### DIFF
--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
@@ -594,7 +594,15 @@
             </fileset>
         </copy>
         <copy file="${install.src}/Version.properties" tofile="${install.dir}/Version.properties" overwrite="true" failonerror="false" force="true"/>
-        <copy file="${install.src}/rx_resources/vm/custom_head.vm" tofile="${install.dir}/rx_resources/vm/custom_head.vm" overwrite="false" failonerror="false"/>
+
+        <!-- Copy custom_head.vm in upgrade -->
+        <copy todir="${install.dir}/rx_resources/vm" overwrite="false" failonerror="false">
+            <fileset dir="${install.src}/rx_resources/vm" defaultexcludes="no">
+                <present present="srconly" targetdir="${install.dir}/rx_resources/vm"/>
+                <include name="custom_head.vm"/>
+            </fileset>
+         </copy>
+
 
         <copy todir="${install.dir}/jetty/base/webapps/Rhythmyx/WEB-INF/config/user" overwrite="false" failonerror="false">
             <fileset dir="${install.src}/jetty/base/webapps/Rhythmyx/WEB-INF/config/user/" followsymlinks="false" includes="**">


### PR DESCRIPTION
CMS-7650: Allow placing of additional head content on pages/templates directly after <head> tag
New install was missing this custom file.