### PR TITLE
CMS-7685: Some Gadgets are not Loading Site Name in the drop down as …

### DIFF
--- a/WebUI/src/com/percussion/webui/gadget/servlets/GadgetSettingsFormServlet.java
+++ b/WebUI/src/com/percussion/webui/gadget/servlets/GadgetSettingsFormServlet.java
@@ -287,7 +287,7 @@ public class GadgetSettingsFormServlet extends HttpServlet
 
 
    private static final String METADATA_SERVICE_URL = "/cm/gadgets/metadata";
-   private static final String PSSESSIONID = "pssessionid";
+   private static final String PSSESSIONID = "JSESSIONID";
 
 
 

--- a/WebUI/src/com/percussion/webui/gadget/servlets/PSUserPrefFormContent.java
+++ b/WebUI/src/com/percussion/webui/gadget/servlets/PSUserPrefFormContent.java
@@ -404,7 +404,7 @@ public class PSUserPrefFormContent {
          {
             String sep = rawurl.indexOf('?') == -1 ? "?" : "&";
             URL lUrl = new URL(m_serverscheme, m_servername,
-               m_serverport, rawurl + sep + "pssessionid=" + m_pssessionid);
+               m_serverport, rawurl);
             url = lUrl.toString();
          }
        


### PR DESCRIPTION
Some Gadgets are not Loading Site Name in the drop down as a result use is not able to see data. e.g Comments, Forms Gadget.

Issue was that pssessionid was added as a query param to the rest API URL and is not required anymore.