### PR TITLE
CMS-7696 : Mini calendar is not working and throwing error in console

### DIFF
--- a/system/Packages/perc.widget.calendar/psx_archiveInfo.xml
+++ b/system/Packages/perc.widget.calendar/psx_archiveInfo.xml
@@ -40,7 +40,7 @@
             <Description>A widget based on Full Calendar (https://fullcalendar.io/).  This widget includes Calendar 1.0 which contains basic calendar support and Calendar 2.0 which adds support for Google Calendar, and iCal support.</Description>
             <Publisher name="Percussion Software" url="http://www.percussion.com"/>
             <CmsVersion max="9.0.0" min="2.5.0"/>
-            <Version>2.3.9</Version>
+            <Version>2.4.0</Version>
             <ImplConfigFile/>
             <LocalConfigFile/>
             <PKGDependencies>

--- a/system/Packages/perc.widget.calendar/sys__UserDependency--rxconfig/Resources/percCalendar.xml
+++ b/system/Packages/perc.widget.calendar/sys__UserDependency--rxconfig/Resources/percCalendar.xml
@@ -36,7 +36,4 @@
 	<file id="calendar_js"  path="/web_resources/widgets/calendar/js/fullcalendar.min.js"  type="javascript" >
 	    <dependency refid="percSystem.jquery"/>
 	</file>
-    	<file id="bbq_js"  path="/web_resources/cm/jslib/jquery.bbq.min.js"  type="javascript" >
-	    <dependency refid="percSystem.jquery"/>
-	</file>
 </Resources>

--- a/system/Packages/perc.widget.calendar/sys__UserDependency--rxconfig/Widgets/percCalendar.xml
+++ b/system/Packages/perc.widget.calendar/sys__UserDependency--rxconfig/Widgets/percCalendar.xml
@@ -275,7 +275,7 @@
                                 jQuery.PercServiceUtils.makeXdmJsonRequest(null,serviceUrl,jQuery.PercServiceUtils.TYPE_POST,function(status, results)
                                 {
                                     if(status == jQuery.PercServiceUtils.STATUS_SUCCESS){
-                                        tempDateArray = results.data.events;
+                                        tempDateArray = jQuery.PercServiceUtils.toJSON(results.data).events;
 
                                      // prepare a temp array of dates which has event associated with it                            
                                      for (var i = 0; i < tempDateArray.length; i++) {            
@@ -296,7 +296,9 @@
                                      });
                                     }
                                     else{
-                                      tempDateArray = callback([]);
+                                        if (typeof(callback) != "undefined"){
+                                                tempDateArray = callback([]);
+                                        }
                                     }
                                 }, dataObj);
                             #end

--- a/system/Packages/perc.widget.calendar/sys__UserDependency--rxconfig/Widgets/percCalendarTwo.xml
+++ b/system/Packages/perc.widget.calendar/sys__UserDependency--rxconfig/Widgets/percCalendarTwo.xml
@@ -798,7 +798,7 @@
                                 jQuery.PercServiceUtils.makeXdmJsonRequest(null,serviceUrl,jQuery.PercServiceUtils.TYPE_POST,function(status, results)
                                 {
                                     if(status == jQuery.PercServiceUtils.STATUS_SUCCESS){
-                                        tempDateArray = results.data.events;
+                                        tempDateArray = jQuery.PercServiceUtils.toJSON(results.data).events;
 
                                      // prepare a temp array of dates which has event associated with it
                                      for (var i = 0; i < tempDateArray.length; i++) {
@@ -821,7 +821,9 @@
                                      });
                                     }
                                     else{
-                                      tempDateArray = callback([]);
+                                        if (typeof(callback) != "undefined"){
+                                            tempDateArray = callback([]);
+                                        }
                                     }
                                 }, dataObj);
                             #end


### PR DESCRIPTION
-  Removed jquery.bbq.min.js reference from calendar.
- Mini calendar not working