### PR TITLE
CMS-7703: 500 Error in console for the gadgets dont have 'All Sites' …

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/pubserver/impl/PSPubServerService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pubserver/impl/PSPubServerService.java
@@ -49,6 +49,7 @@ import com.percussion.services.pubserver.data.PSPubServer;
 import com.percussion.services.pubserver.data.PSPubServerProperty;
 import com.percussion.services.sitemgr.IPSSite;
 import com.percussion.services.sitemgr.IPSSiteManager;
+import com.percussion.share.data.PSEnumVals;
 import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.share.validation.PSValidationErrorsBuilder;
 import com.percussion.sitemanage.dao.impl.PSSitePublishDao;
@@ -2125,9 +2126,22 @@ public class PSPubServerService implements IPSPubServerService
     public String getDefaultAdminURL(String siteName) throws PSPubServerServiceException {
 
         IPSSite site = siteMgr.findSite(siteName);
-        PSPubServer currentDefaultServer = getDefaultPubServer(site.getGUID());
-        String adminUrl= currentDefaultServer.getPropertyValue("publishServer");
-        return adminUrl;
+        if(site == null){
+            PSEnumVals sites = siteDataService.getChoices();
+            List siteNames = sites.getEntries();
+            if(siteNames != null && siteNames.size() > 0){
+                siteName = ((PSEnumVals.EnumVal)siteNames.get(0)).getValue();
+                site = siteMgr.findSite(siteName);
+            }
+        }
+        if(site == null){
+            log.info("No Site found in the system");
+            return null;
+        }else {
+            PSPubServer currentDefaultServer = getDefaultPubServer(site.getGUID());
+            String adminUrl = currentDefaultServer.getPropertyValue("publishServer");
+            return adminUrl;
+        }
     }
 
 }


### PR DESCRIPTION
 500 Error in console for the gadgets dont have 'All Sites'  option for e.g Traffic, Forms Tracker, Membership. Also data of one site is showing in another site.

Fixed it on server side to pick any first site from the list, incase UI passes "undefined" or null. as in case user has selected "Assests" and not on Sites tab, then no default site selected.