### PR TITLE
CMS-76748.0.0 upgrade incorrectly replaces Tomcat with https.keystore…

### DIFF
--- a/system/Tools/Ant/src/main/java/com/percussion/ant/install/PSUpdateDTSConfiguration.java
+++ b/system/Tools/Ant/src/main/java/com/percussion/ant/install/PSUpdateDTSConfiguration.java
@@ -147,7 +147,14 @@ public class PSUpdateDTSConfiguration extends PSAction {
 
                         } else if (scheme.equals("https")) {
                             Map<String, String> oldProps = connector.getProperties();
-
+                            //We don't want to keep default values, thus clearing them first and restoring them from old.
+                            properties.put("https.port","");
+                            properties.put("https.certificateKeystoreFile","");
+                            properties.put("https.keystoreFile","");
+                            properties.put("https.certificateKeystorePassword" , "");
+                            properties.put("https.keystorePass" , "");
+                            properties.put("https.certificateKeyAlias", "");
+                            properties.put("https.keyAlias", "");
                             for (String key : oldProps.keySet()) {
                                 if(key.equals("port") ) {
                                     properties.put("https." + key, oldProps.get(key));


### PR DESCRIPTION
Upgraded eval server with latest nightly.  DTS fails to start with the following:

In this case there was no keyalias set on 5.3.  But upgrading to 8.0.2 adds the tomcat alias.  This fails as tomcat is not an alias in the customers keystore.File=conf/.keystore