### PR TITLE
CMS-7697 : Upgrading CM1 AFTER upgrading DTS causes all DTS / Staging DTS *.sh scripts to incorrectly be removed

### DIFF
--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
@@ -397,8 +397,6 @@
         <include name="jetty/upstream/**"/>
         <include name="jetty/defaults/**"/>
         <include name="jetty/base/webapps/**"/>
-        <include name="**/*.bat"/>
-        <include name="**/*.sh"/>
     </patternset>
 
     <patternset id="upgrade.excludes">


### PR DESCRIPTION
@natechadwick This was because the script was deliberately deleting the *.bat & *.sh files. I have committed the code for the fix. After this code change these files are not deleted. I also re upgraded DTS and observed that the old *.bat / *.sh files are overwritten after upgrade. So, if the old files needs to be replaced then the DTS upgrade does that. Please review and let me know.