### PR TITLE
CMS-7885 : EMS Event widget is not editable

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/integrations/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/integrations/pom.xml
@@ -129,6 +129,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-jaxb</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>${javax.annotation.version}</version>


### PR DESCRIPTION
CMS-7724 : By Adding EMS EVENT LIST widget and accessing the content tab error message gets displayed