### PR TITLE
CMS_7800_7914_7915

### DIFF
--- a/system/src/com/percussion/cms/objectstore/server/PSRelationshipProcessor.java
+++ b/system/src/com/percussion/cms/objectstore/server/PSRelationshipProcessor.java
@@ -303,7 +303,12 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor
             if(rel1.getConfig().equals(rel.getConfig())){
                if(rel1.getDependent().getRevision() == rel.getDependent().getRevision()){
                   if(rel1.getOwner().getRevision() == rel.getOwner().getRevision()){
-                     if(rel1.getUserProperty(PSRelationshipConfig.PDU_SLOTID).getValue() == rel.getUserProperty(PSRelationshipConfig.PDU_SLOTID).getValue()){
+                     //Checking this slot id to resolve the page summary issue if same image is uploaded in page summary and image widget for the same page (CMS-7800).
+                     if(rel.getUserProperty(PSRelationshipConfig.PDU_SLOTID) != null && rel1.getUserProperty(PSRelationshipConfig.PDU_SLOTID) != null){
+                        if(rel1.getUserProperty(PSRelationshipConfig.PDU_SLOTID).getValue().equalsIgnoreCase(rel.getUserProperty(PSRelationshipConfig.PDU_SLOTID).getValue())){
+                           return rel1;
+                        }
+                     }else{
                         return rel1;
                      }
                   }


### PR DESCRIPTION
CMS-7800 : Broken link gets displayed instead of Image on Editor wherein Page Auto list widget is added.
CMS-7914 : When user try to add template, After giving the template name "500 Server Error" message gets displayed in console.
CMS-7915 : By adding a name to the created template and revisiting the Design tab, Template name is not getting retained.

This change works for all the above tickets.