### PR TITLE
CMS-8024 : Social Buttons widget configured with 'Hide buttons on mobile' does not hide the buttons on mobile.

### DIFF
--- a/system/Packages/perc.widget.socialButtons/psx_archiveInfo.xml
+++ b/system/Packages/perc.widget.socialButtons/psx_archiveInfo.xml
@@ -40,7 +40,7 @@
             <Description/>
             <Publisher name="https://www.percussion.com" url="https://www.percussion.com"/>
             <CmsVersion max="9.0.0" min="5.3.15"/>
-            <Version>1.1.11</Version>
+            <Version>1.1.12</Version>
             <ImplConfigFile/>
             <LocalConfigFile/>
             <PKGDependencies>

--- a/system/Packages/perc.widget.socialButtons/sys__UserDependency--rxconfig/Widgets/percSocialButtons.xml
+++ b/system/Packages/perc.widget.socialButtons/sys__UserDependency--rxconfig/Widgets/percSocialButtons.xml
@@ -66,7 +66,7 @@
         <EnumValue value="bottom" display_value="Fixed Bottom" />
     </UserPref>
     <UserPref name="mobileBreakpoint"
-              display_name="Mobile breakpoint screen size"
+              display_name="Mobile breakpoint screen size (Specify units px, em, % etc.)"
               required="true"
               datatype="string" default_value="1024px">
     </UserPref>


### PR DESCRIPTION
Changed the mobile break point label to mention units