### PR TITLE
CMS-8176 : On Moderation pop-up, site name is showing as 'undefined' and Error appear on screen while saving the Moderation default for 'Comments' gadget.

### DIFF
--- a/system/Packages/perc.gadget.comments/sys__UserDependency--cm/gadgets/repository/perc_comments_gadget/perc_comments_gadget.js
+++ b/system/Packages/perc.gadget.comments/sys__UserDependency--cm/gadgets/repository/perc_comments_gadget/perc_comments_gadget.js
@@ -240,7 +240,8 @@
      */
     
     function displayDefaultModerationDialog(evt) {
-        var link = $(this);
+        //CMS-8176 : as event is passed so $(this) returned event instead of link, thus site was undefined and also causing save error.
+        var link = $("#perc-set-default-moderation-link");
         var site = link.attr("site");
         
         $.PercCommentsGadgetService().getDefaultCommentModeration(site,


### PR DESCRIPTION
As event is passed so $(this) returned event instead of link, thus site was undefined and also causing save error.