### PR TITLE
CMS-8322 : Category list Widget giving console errors on editor, preview and published pages.

### DIFF
--- a/modules/perc-distribution-tree/src/main/resources/installDistributionFiles.xml
+++ b/modules/perc-distribution-tree/src/main/resources/installDistributionFiles.xml
@@ -265,6 +265,8 @@
         <!-- jQuery.cookie-->
         <copy tofile="${assembly-directory}/web_resources/cm/jslib/jquery.cookie.js" file="${assembly-directory}/jetty/base/webapps/Rhythmyx/cm/jslib/profiles/3x/jquery/plugins/jquery-perc-retiredjs/jquery.cookie.js"/>
         <copy tofile="${assembly-directory}/web_resources/cm/jslib/jquery.cookie.min.js" file="${assembly-directory}/jetty/base/webapps/Rhythmyx/cm/jslib/profiles/3x/jquery/plugins/jquery-perc-retiredjs/jquery.cookie.js"/>
+        <!-- jQuery.dynatree -->
+        <copy tofile="${assembly-directory}/web_resources/cm/jslib/jquery.dynatree.js" file="${assembly-directory}/jetty/base/webapps/Rhythmyx/cm/jslib/profiles/3x/jquery/plugins/jquery-dynatree/jquery.dynatree.js"/>
         <copy tofile="${assembly-directory}/web_resources/cm/css/dynatree/skin/ui.dynatree.css" file="${assembly-directory}/jetty/base/webapps/Rhythmyx/cm/css/dynatree/skin/ui.dynatree.css"/>
         <copy tofile="${assembly-directory}/web_resources/cm/css/dynatree/skin/vline.gif" file="${assembly-directory}/jetty/base/webapps/Rhythmyx/cm/css/dynatree/skin/vline.gif"/>
         <copy tofile="${assembly-directory}/web_resources/cm/css/dynatree/skin/loading.gif" file="${assembly-directory}/jetty/base/webapps/Rhythmyx/cm/css/dynatree/skin/loading.gif"/>

--- a/system/Packages/perc.widget.categoryList/psx_archiveInfo.xml
+++ b/system/Packages/perc.widget.categoryList/psx_archiveInfo.xml
@@ -40,7 +40,7 @@
             <Description>Show a tree of page categories</Description>
             <Publisher name="Percussion Software Inc." url="https://www.percussion.com/"/>
             <CmsVersion max="9.0.0" min="1.9.0"/>
-            <Version>1.2.1</Version>
+            <Version>1.2.2</Version>
             <ImplConfigFile/>
             <LocalConfigFile/>
             <PKGDependencies>

--- a/system/Packages/perc.widget.categoryList/sys__UserDependency--rxconfig/Resources/percCategoryList.xml
+++ b/system/Packages/perc.widget.categoryList/sys__UserDependency--rxconfig/Resources/percCategoryList.xml
@@ -32,7 +32,7 @@
         <dependency refid="percSystem.jquery"/>
     </file>
     <file path="/web_resources/cm/css/dynatree/skin/ui.dynatree.css" type="css" id="jquery-dynatree_css"/>
-    <file id="jquery-dynatree_js" path="/web_resources/cm/jslib/jquery.dynatree.min.js" type="javascript">
+    <file id="jquery-dynatree_js" path="/web_resources/cm/jslib/jquery.dynatree.js" type="javascript">
         <dependency refid="percSystem.jquery" />
         <dependency refid="percSystem.jquery-ui" />
     </file>


### PR DESCRIPTION
Including **jquery.dynatree.js** as **jquery.dynatree.min.js** is not available to be copied from **${assembly-directory}/jetty/base/webapps/Rhythmyx/cm/jslib/profiles/3x/jquery/plugins/jquery-dynatree/** this location only **jquery.dynatree.js** file is available. 