### PR TITLE
CMS-8393 - Expand banned paths in the dispatch servlet.  

### DIFF
--- a/system/ear/WEB-INF/web.xml
+++ b/system/ear/WEB-INF/web.xml
@@ -1066,4 +1066,15 @@
         <res-auth>Container</res-auth>
         <res-sharing-scope>Shareable</res-sharing-scope>
     </resource-ref>
+
+    <error-page>
+        <error-code>404</error-code>
+        <location>/ui/default-error.html</location>
+    </error-page>
+
+    <error-page>
+        <error-code>403</error-code>
+        <location>/ui/default-error.html</location>
+    </error-page>
+
 </web-app>

--- a/system/ear/jsps/test/countFolderItem.jsp
+++ b/system/ear/jsps/test/countFolderItem.jsp
@@ -22,14 +22,12 @@
         isEnabled="false";
 
     if(isEnabled.equalsIgnoreCase("false")){
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
     }
     String fullrolestr = PSRoleUtilities.getUserRoles();
 
     if (!fullrolestr.contains("Admin"))
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
 
 %>
 <%--

--- a/system/ear/jsps/test/index.jsp
+++ b/system/ear/jsps/test/index.jsp
@@ -32,14 +32,12 @@
         isEnabled="false";
 
     if(isEnabled.equalsIgnoreCase("false")){
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
     }
     String fullrolestr = PSRoleUtilities.getUserRoles();
 
     if (!fullrolestr.contains("Admin"))
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
 
 %>
 <html>

--- a/system/ear/jsps/test/jnditest.jsp
+++ b/system/ear/jsps/test/jnditest.jsp
@@ -12,14 +12,12 @@
 		isEnabled="false";
 
 	if(isEnabled.equalsIgnoreCase("false")){
-		response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-				+ "/ui/RxNotAuthorized.jsp"));
+		response.sendError(HttpServletResponse.SC_NOT_FOUND);
 	}
 	String fullrolestr = PSRoleUtilities.getUserRoles();
 
 	if (!fullrolestr.contains("Admin"))
-		response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-				+ "/ui/RxNotAuthorized.jsp"));
+		response.sendError(HttpServletResponse.SC_NOT_FOUND);
 
 %>
 <%--

--- a/system/ear/jsps/test/logs.jsp
+++ b/system/ear/jsps/test/logs.jsp
@@ -37,14 +37,12 @@
         isEnabled="false";
 
     if(isEnabled.equalsIgnoreCase("false")){
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
     }
     String fullrolestr = PSRoleUtilities.getUserRoles();
 
     if (!fullrolestr.contains("Admin"))
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
 
 %>
 <!DOCTYPE html>

--- a/system/ear/jsps/test/search.jsp
+++ b/system/ear/jsps/test/search.jsp
@@ -27,13 +27,11 @@
       isEnabled="false";
 
    if(isEnabled.equalsIgnoreCase("false")){
-      response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-              + "/ui/RxNotAuthorized.jsp"));
+      response.sendError(HttpServletResponse.SC_NOT_FOUND);
    }
 
    if (!fullrolestr.contains("Admin"))
-      response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-              + "/ui/RxNotAuthorized.jsp"));
+      response.sendError(HttpServletResponse.SC_NOT_FOUND);
 
 %>
 

--- a/system/ear/jsps/test/setItemCommunity.jsp
+++ b/system/ear/jsps/test/setItemCommunity.jsp
@@ -48,14 +48,12 @@
         isEnabled="false";
 
     if(isEnabled.equalsIgnoreCase("false")){
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
     }
     String fullrolestr = PSRoleUtilities.getUserRoles();
 
     if (!fullrolestr.contains("Admin"))
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
 
 %>
 <!DOCTYPE html>

--- a/system/ear/jsps/test/setItemCommunitySkip.jsp
+++ b/system/ear/jsps/test/setItemCommunitySkip.jsp
@@ -47,14 +47,12 @@
         isEnabled="false";
 
     if(isEnabled.equalsIgnoreCase("false")){
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
     }
     String fullrolestr = PSRoleUtilities.getUserRoles();
 
     if (!fullrolestr.contains("Admin"))
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
 
 %>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">

--- a/system/ear/jsps/test/sql.jsp
+++ b/system/ear/jsps/test/sql.jsp
@@ -59,13 +59,11 @@ String isEnabled = PSServer.getServerProps().getProperty("enableDebugTools");
         isEnabled="false";
 
 if(isEnabled.equalsIgnoreCase("false")){
-   	response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-   	      	+ "/ui/RxNotAuthorized.jsp"));
+   	response.sendError(HttpServletResponse.SC_NOT_FOUND);
 }
 
 if (!fullrolestr.contains("Admin"))
-   	response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-      	+ "/ui/RxNotAuthorized.jsp"));
+   	response.sendError(HttpServletResponse.SC_NOT_FOUND);
 
 %>
 <!DOCTYPE html>

--- a/system/ear/jsps/test/unusedassets.jsp
+++ b/system/ear/jsps/test/unusedassets.jsp
@@ -23,14 +23,12 @@ import="com.percussion.server.PSServer"
 		isEnabled="false";
 
 	if(isEnabled.equalsIgnoreCase("false")){
-		response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-				+ "/ui/RxNotAuthorized.jsp"));
+		response.sendError(HttpServletResponse.SC_NOT_FOUND);
 	}
 	String fullrolestr = PSRoleUtilities.getUserRoles();
 
 	if (!fullrolestr.contains("Admin"))
-		response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-				+ "/ui/RxNotAuthorized.jsp"));
+		response.sendError(HttpServletResponse.SC_NOT_FOUND);
 
 %>
 <%!
@@ -60,9 +58,8 @@ response.setHeader("Content-Disposition", "attachment; filename=unusedassets.csv
 IPSContentMgr mgr = PSContentMgrLocator.getContentMgr();
 String fullrolestr = PSRoleUtilities.getUserRoles();
 
-if (fullrolestr.contains("Admin") == false)
-   	response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-      	+ "/ui/RxNotAuthorized.jsp"));
+if (!fullrolestr.contains("Admin"))
+   	response.sendError(HttpServletResponse.SC_NOT_FOUND);
 
 String dburl="java:jdbc/RhythmyxData";
 

--- a/system/ear/jsps/test/updateFolderSecurity.jsp
+++ b/system/ear/jsps/test/updateFolderSecurity.jsp
@@ -48,14 +48,12 @@
         isEnabled="false";
 
     if(isEnabled.equalsIgnoreCase("false")){
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
     }
     String fullrolestr = PSRoleUtilities.getUserRoles();
 
     if (!fullrolestr.contains("Admin"))
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
 
 %>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">

--- a/system/ear/jsps/test/velocitylog.jsp
+++ b/system/ear/jsps/test/velocitylog.jsp
@@ -37,14 +37,12 @@
         isEnabled="false";
 
     if(isEnabled.equalsIgnoreCase("false")){
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
     }
     String fullrolestr = PSRoleUtilities.getUserRoles();
 
     if (!fullrolestr.contains("Admin"))
-        response.sendRedirect(response.encodeRedirectURL(request.getContextPath()
-                + "/ui/RxNotAuthorized.jsp"));
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
 
 %>
 <%

--- a/system/ear/jsps/ui/admin/AdminAuthentication.jsp
+++ b/system/ear/jsps/ui/admin/AdminAuthentication.jsp
@@ -29,7 +29,6 @@
 <%
 	if (!PSTopNavigation.hasAdminCompRoles())
 	{
-   	response.sendRedirect(response.encodeUrl(request.getContextPath()
-      	+ "/ui/RxNotAuthorized.jsp"));
+   	response.sendError(HttpServletResponse.SC_NOT_FOUND);
 	}
 %>

--- a/system/ear/jsps/ui/publishing/PubDesignAuthentication.jsp
+++ b/system/ear/jsps/ui/publishing/PubDesignAuthentication.jsp
@@ -29,7 +29,6 @@
 <%
 	if (!PSTopNavigation.hasPubDesignCompRoles())
 	{
-   	response.sendRedirect(response.encodeUrl(request.getContextPath()
-      	+ "/ui/RxNotAuthorized.jsp"));
+   	response.sendError(HttpServletResponse.SC_NOT_FOUND);
 	}
 %>

--- a/system/ear/jsps/ui/pubruntime/PubRuntimeAuthentication.jsp
+++ b/system/ear/jsps/ui/pubruntime/PubRuntimeAuthentication.jsp
@@ -29,7 +29,6 @@
 <%
 	if (!PSTopNavigation.hasPubRuntimeCompRoles())
 	{
-   	response.sendRedirect(response.encodeUrl(request.getContextPath()
-      	+ "/ui/RxNotAuthorized.jsp"));
+   	response.sendError(HttpServletResponse.SC_NOT_FOUND);
 	}
 %>

--- a/system/src/com/percussion/servlets/PSDispatcherFilter.java
+++ b/system/src/com/percussion/servlets/PSDispatcherFilter.java
@@ -41,7 +41,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -54,7 +54,17 @@ public class PSDispatcherFilter implements Filter {
     private static final Pattern pattern = Pattern.compile("^.+\\/\\/[^\\/]+\\/Sites\\/([^\\/]*)", Pattern.MULTILINE);
 
     private static final String[] bannedPaths = new String[]{
-            "/WEB-INF/"
+            "/WEB-INF/",
+            "/lib/",
+            "/bin/",
+            "/backups/",
+            "/jetty/",
+            "/logs/",
+            "/temp/",
+            "/util/",
+            "/user/",
+            "/patch/",
+            "/css/"
     };
 
     private static final String[] resourcePaths = new String[] {
@@ -113,8 +123,9 @@ public class PSDispatcherFilter implements Filter {
         String strippedPath = path.startsWith(RHYTHMYX) ? StringUtils.substringAfter(path,RHYTHMYX) : path;
         String newPath = path;
 
-        if(Stream.of(bannedPaths).anyMatch(strippedPath::contains)){
-            ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+        if(Stream.of(bannedPaths).anyMatch(strippedPath::startsWith)){
+     //       ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_NOT_FOUND);
+            ((HttpServletResponse) response).sendError(HttpServletResponse.SC_NOT_FOUND);
             return;
         }
 
@@ -150,7 +161,7 @@ public class PSDispatcherFilter implements Filter {
                 String site =null;
                 try {
 
-                    List<NameValuePair> params = URLEncodedUtils.parse(new URI(referrer), Charset.forName("UTF-8"));
+                    List<NameValuePair> params = URLEncodedUtils.parse(new URI(referrer), StandardCharsets.UTF_8);
                     NameValuePair siteParam = null;
                     /*NameValuePair siteParam = params.stream()
                             .filter(p -> p.getName().equals("site"))

--- a/system/src/com/percussion/servlets/PSDispatcherFilter.java
+++ b/system/src/com/percussion/servlets/PSDispatcherFilter.java
@@ -124,7 +124,6 @@ public class PSDispatcherFilter implements Filter {
         String newPath = path;
 
         if(Stream.of(bannedPaths).anyMatch(strippedPath::startsWith)){
-     //       ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_NOT_FOUND);
             ((HttpServletResponse) response).sendError(HttpServletResponse.SC_NOT_FOUND);
             return;
         }


### PR DESCRIPTION
Return 404 instead of 302 / 403 for access denied in JSPs that test authorization.

Banned paths are now:

            "/WEB-INF/",
            "/lib/",
            "/bin/",
            "/backups/",
            "/jetty/",
            "/logs/",
            "/temp/",
            "/util/",
            "/user/",
            "/patch/",
            "/css/"