### PR TITLE
merge from dev CMS-9333 - Fix issue where items with names that inclu…

### DIFF
--- a/WebUI/war/app/index.jsp
+++ b/WebUI/war/app/index.jsp
@@ -310,6 +310,7 @@
             path = path.replace("//Sites/","/Sites/");
             String siteName = path.replace("/Sites/","").split("/")[0];
             path = URLEncoder.encode(path,"UTF-8");
+            pageName = URLEncoder.encode(pageName,"UTF-8");
             temp = item.getId();
             String pageId = temp != null?temp.toString():"";
             urlParams.put("site", siteName);

--- a/modules/perc-security-utils/src/main/java/com/percussion/security/SecureStringUtils.java
+++ b/modules/perc-security-utils/src/main/java/com/percussion/security/SecureStringUtils.java
@@ -249,9 +249,8 @@ public class SecureStringUtils {
         return id.matches("^[0-9-]*$");
     }
 
-
     /**
-     * Checks if the supplied string doesn't have an invalid character.
+     * Checks if the supplied string has any known xss characters.
      * @param string the stringto test
      * @return true if the string is valid, false if not
      */
@@ -259,8 +258,7 @@ public class SecureStringUtils {
         if(string == null || string.trim().equals("")){
             return true;
         }
-
-         return string.matches("[a-zA-Z0-9,.;/=?@*%\\[\\]()&:_'\\s-]*");
+       return !containsXSSChars(string);
     }
 
     /**

--- a/modules/perc-security-utils/src/test/java/TestSecureStringUtils.java
+++ b/modules/perc-security-utils/src/test/java/TestSecureStringUtils.java
@@ -217,4 +217,11 @@ public class TestSecureStringUtils {
         assertTrue(t.length() <= SecureStringUtils.MAX_FILENAME_LEN);
     }
 
+    @Test
+    public void testValidString(){
+        assertFalse(SecureStringUtils.isValidString("<script>alert(111);</script>"));
+        assertTrue(SecureStringUtils.isValidString("somestring"));
+        assertTrue(SecureStringUtils.isValidString("se-inicia-la-postulación-al-fondo-concursable-para-apoyar-tu-practica-en-el-extranjero"));
+    }
+
 }

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSPageUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSPageUtils.java
@@ -3030,6 +3030,13 @@ public class PSPageUtils extends PSJexlUtilBase
         return true;
     }
 
+    public boolean isValidPercId(String str){
+        if(!SecureStringUtils.isValidPercId(str)){
+            throw new IllegalArgumentException("Invalid Param: " + str);
+        }
+        return true;
+    }
+
     public void setPubServerService(IPSPubServerService pubServerService)
     {
         this.pubServerService = pubServerService;


### PR DESCRIPTION
…de unicode characters like ó were getting 403 due to bad regex that was ascii only.  Updated the isValidString to use the XSS check instead.