### PR TITLE
Update POI for CVE-2022-26336, bump log4j2

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/pom.xml
@@ -84,7 +84,7 @@
         <axis.version>1.4.1</axis.version>
         <axiscore.version>1.4.2</axiscore.version>
         <httpcomponents.version>4.5.8</httpcomponents.version>
-        <log4j2.version>2.17.1</log4j2.version>
+        <log4j2.version>2.18.0</log4j2.version>
         <tika.version>1.17</tika.version>
         <xmpbox.version>2.0.17</xmpbox.version>
         <jbig2.version>3.0.2</jbig2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
        <myfaces.version>1.1.8</myfaces.version>
        <simplexml.version>2.7.1</simplexml.version>
        <stax.version>1.0.1</stax.version>
-        <poi.version>4.1.2</poi.version>
+        <poi.version>5.2.2</poi.version>
         <esapi.version>2.3.0.0</esapi.version>
         <esapi.encoder.version>1.2.3</esapi.encoder.version>
         <ant.version>1.10.11</ant.version>
@@ -190,7 +190,7 @@
        <twelvemonkeys.version>3.7.1</twelvemonkeys.version>
        <commons.beanutils.version>1.9.4</commons.beanutils.version>
        <xstream.version>1.4.19</xstream.version>
-       <log4j2.version>2.17.2</log4j2.version>
+       <log4j2.version>2.18.0</log4j2.version>
        <guava.version>29.0-jre</guava.version>
        <xerces.version>2.12.2</xerces.version>
        <quartz.version>2.3.2</quartz.version>

--- a/system/src/main/java/com/percussion/search/lucene/textconverter/PSTextConverterMsPowerPoint.java
+++ b/system/src/main/java/com/percussion/search/lucene/textconverter/PSTextConverterMsPowerPoint.java
@@ -28,8 +28,7 @@ import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
 import com.percussion.search.lucene.IPSLuceneConstants;
 import org.apache.poi.extractor.POITextExtractor;
-import org.apache.poi.hslf.extractor.PowerPointExtractor;
-import org.apache.poi.xslf.extractor.XSLFPowerPointExtractor;
+import org.apache.poi.sl.extractor.SlideShowExtractor;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
 
 import java.io.File;
@@ -71,14 +70,14 @@ public class PSTextConverterMsPowerPoint implements IPSLuceneTextConverter
       if (IPSLuceneConstants.MIME_TYPE_APPLICATION_BY_MSPOWERPOINT.equalsIgnoreCase(mimetype) || 
             IPSLuceneConstants.MIME_TYPE_APPLICATION_BY_VNDMSPOWERPOINT.equalsIgnoreCase(mimetype))
       {
-         PowerPointExtractor ppext = new PowerPointExtractor(is);
+         SlideShowExtractor ppext = new SlideShowExtractor(new XMLSlideShow(is));
          ppext.setNotesByDefault(true);
          ppext.setSlidesByDefault(true);
          extractor = ppext;
       }
       else
       {
-         XSLFPowerPointExtractor ppext = new XSLFPowerPointExtractor(new XMLSlideShow(is));
+         SlideShowExtractor ppext = new SlideShowExtractor(new XMLSlideShow(is));
          ppext.setNotesByDefault(true);
          ppext.setSlidesByDefault(true);
          extractor = ppext;


### PR DESCRIPTION
clear POI alert, the powerpoint extractors were deprecated and removed in this version of POI and the code needed updated.  They are used in the lucene indexing.