### PR TITLE
Add extension call to unescape rich text xml content

### DIFF
--- a/system/cms/content/applications/sys_resources/ApplicationFiles/stylesheets/sys_Templates.xsl
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/stylesheets/sys_Templates.xsl
@@ -7,13 +7,14 @@
         ]>
 <xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:psxctl="urn:percussion.com/control"
-                xmlns:xmns="http://www.w3.org/1999/xhtml"
                 xmlns="http://www.w3.org/1999/xhtml" xmlns:psxi18n="com.percussion.i18n"
-                extension-element-prefixes="psxi18n" exclude-result-prefixes="psxi18n psxctl xmns">
+                extension-element-prefixes="psxi18n escape-util"
+                exclude-result-prefixes="psxi18n psxctl xmns escape-util">
 
    <xsl:import href="file:sys_resources/stylesheets/sys_I18nUtils.xsl"/>
    <!-- write the xml header according to XHTML 1.0 spec -->
-   <xsl:output method="xml" standalone="yes" indent="yes" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="DTD/xhtml1-strict.dtd" encoding="UTF-8" />
+   <xsl:output method="text" standalone="yes" indent="yes" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="DTD/xhtml1-strict.dtd" encoding="UTF-8" />
+   <xsl:script implements-prefix="escape-util" language="java" src="java:org.apache.commons.lang.StringEscapeUtils"/>
    <xsl:variable name="itemLocale" select="/ContentEditor/@itemLocale"/>
 
    <!--
@@ -458,12 +459,12 @@ accept      %ContentTypes; #IMPLIED
             <psxctl:DefaultValue>POPUP</psxctl:DefaultValue>
          </psxctl:Param>
       </psxctl:ParamList>
-	  <psxctl:AssociatedFileList>
-	  <psxctl:FileDescriptor name="PercFileSelectionControl.js" type="script" mimetype="text/javascript">
+      <psxctl:AssociatedFileList>
+         <psxctl:FileDescriptor name="PercFileSelectionControl.js" type="script" mimetype="text/javascript">
             <psxctl:FileLocation>/sys_resources/js/cm/init.js</psxctl:FileLocation>
             <psxctl:Timestamp/>
          </psxctl:FileDescriptor>
-	     <psxctl:FileDescriptor name="PercFileSelectionControl.js" type="script" mimetype="text/javascript">
+         <psxctl:FileDescriptor name="PercFileSelectionControl.js" type="script" mimetype="text/javascript">
             <psxctl:FileLocation>/sys_resources/js/browser.js</psxctl:FileLocation>
             <psxctl:Timestamp/>
          </psxctl:FileDescriptor>
@@ -539,7 +540,7 @@ accept      %ContentTypes; #IMPLIED
          '&amp;sys_submitname=',@paramName,'&amp;sys_childrowid=',$childkey)"/>
          <!-- childid if it exists -->
       </xsl:variable>
-	        <xsl:variable name="fileBase"><xsl:value-of select="@paramName"/></xsl:variable>
+      <xsl:variable name="fileBase"><xsl:value-of select="@paramName"/></xsl:variable>
       <xsl:variable name="item_title"><xsl:value-of select="//Control[@paramName='sys_title']/Value"/></xsl:variable>
       <xsl:variable name="binary_type"><xsl:value-of select="//Control[@paramName=concat($fileBase,'_type')]/Value"/></xsl:variable>
       <xsl:variable name="binary_ext"><xsl:value-of select="//Control[@paramName=concat($fileBase,'_ext')]/Value"/></xsl:variable>
@@ -3446,11 +3447,11 @@ onchange    %Script;       #IMPLIED
          </psxctl:Param>
       </psxctl:ParamList>
       <psxctl:AssociatedFileList>
-	  <psxctl:FileDescriptor name="PercFileSelectionControl.js" type="script" mimetype="text/javascript">
+         <psxctl:FileDescriptor name="PercFileSelectionControl.js" type="script" mimetype="text/javascript">
             <psxctl:FileLocation>/sys_resources/js/cm/init.js</psxctl:FileLocation>
             <psxctl:Timestamp/>
          </psxctl:FileDescriptor>
-	     <psxctl:FileDescriptor name="PercFileSelectionControl.js" type="script" mimetype="text/javascript">
+         <psxctl:FileDescriptor name="PercFileSelectionControl.js" type="script" mimetype="text/javascript">
             <psxctl:FileLocation>/sys_resources/js/browser.js</psxctl:FileLocation>
             <psxctl:Timestamp/>
          </psxctl:FileDescriptor>
@@ -3673,7 +3674,7 @@ onchange    %Script;       #IMPLIED
             <psxctl:FileLocation>/sys_resources/js/cm/init.js</psxctl:FileLocation>
             <psxctl:Timestamp/>
          </psxctl:FileDescriptor>
-	     <psxctl:FileDescriptor name="browser.js" type="script" mimetype="text/javascript">
+         <psxctl:FileDescriptor name="browser.js" type="script" mimetype="text/javascript">
             <psxctl:FileLocation>/sys_resources/js/browser.js</psxctl:FileLocation>
             <psxctl:Timestamp/>
          </psxctl:FileDescriptor>
@@ -4101,7 +4102,9 @@ onchange    %Script;       #IMPLIED
          <xsl:if test="@accessKey!=''">
             <xsl:attribute name="accesskey"><xsl:call-template name="getaccesskey"><xsl:with-param name="label" select="preceding-sibling::DisplayLabel"/><xsl:with-param name="sourceType" select="preceding-sibling::DisplayLabel/@sourceType"/><xsl:with-param name="paramName" select="@paramName+$uniqueName"/><xsl:with-param name="accessKey" select="@accessKey"/></xsl:call-template></xsl:attribute>
          </xsl:if>
-         <xsl:value-of select="Value"/>
+         <xsl:text>
+            <xsl:value-of select="escape-util:unescapeXml(Value)" disable-output-escaping="yes" />
+         </xsl:text>
       </textarea>
       <!--</div>-->
    </xsl:template>


### PR DESCRIPTION
Updates sys_Templates.xsl to unescape the xml encoded rich text value.