### PR TITLE
Get rid of intermittent battleship grey body backgrounds

### DIFF
--- a/WebUI/war/app/pageNotFound.jsp
+++ b/WebUI/war/app/pageNotFound.jsp
@@ -34,7 +34,7 @@
         <script src="/Rhythmyx/tmx/tmx.jsp?mode=js&amp;prefix=perc.ui.&amp;sys_lang=<%=locale%>"></script>
         <script src="/JavaScriptServlet"></script>
         <style>
-        body {background-color: #6C717C; font-family: Verdana; margin: 0; padding: 0; }
+        body { font-family: Verdana; margin: 0; padding: 0; }
         .perc-login-logo { font-size: 48px; color: #121212; margin-top: 160px; margin-bottom: 100px;}
         #loginform .perc-form    {font-size: 14px; }
         #perc-forgot {color: #fff;}

--- a/WebUI/war/css/layout.css
+++ b/WebUI/war/css/layout.css
@@ -153,7 +153,6 @@ table {
 
 .perc-main .perc-header {
     height: 43px;
-    -background-color: #6C717C;
     background-color: #133c55;
 }
 .perc-main .perc-header .perc-logo   {

--- a/system/ear/jsps/maintenance-errors.jsp
+++ b/system/ear/jsps/maintenance-errors.jsp
@@ -16,7 +16,7 @@
     <head>
         <title>${rxcomp:i18ntext('jsp_maintenance@Maintenance',locale)}</title> 
         <style type="text/css">
-         body {background-color: #6C717C; font-family: Verdana; margin: 0; padding: 0; }
+         body { font-family: Verdana; margin: 0; padding: 0; }
         .perc-login-logo { font-size: 48px; color: #121212; margin-top: 160px; margin-bottom: 100px;}
         .perc-warning-message { width:500px; text-align:center;}
         .perc-warning-message a { color: #CCCCCC; text-decoration: none; font-weight: bold; }

--- a/system/ear/jsps/maintenance.jsp
+++ b/system/ear/jsps/maintenance.jsp
@@ -18,7 +18,7 @@
     <head>
         <title>${rxcomp:i18ntext('jsp_maintenance@Maintenance',locale)}</title> 
         <style type="text/css">
-         body {background-color: #6C717C; font-family: Verdana; margin: 0; padding: 0; }
+         body { font-family: Verdana; margin: 0; padding: 0; }
         .perc-login-logo { font-size: 48px; color: #121212; margin-top: 160px; margin-bottom: 100px;}
         .perc-warning-message { width:500px; text-align:center;}
         .perc-warning-message a { color: #CCCCCC; text-decoration: none; font-weight: bold; }

--- a/system/ear/jsps/rxlogin.jsp
+++ b/system/ear/jsps/rxlogin.jsp
@@ -46,7 +46,7 @@
 <head>
 	<title>${rxcomp:i18ntext('jsp_login@Percussion Login',locale)}</title>
 	<style>
-		body {background-color: #6C717C;
+		body {
 			font-family: Verdana, serif; margin: 0; padding: 0; }
 		.perc-login-logo {color: #121212; margin-top: 50px; margin-bottom: 50px;}
 		#loginform .perc-form    { }

--- a/system/ear/jsps/rxlogout.jsp
+++ b/system/ear/jsps/rxlogout.jsp
@@ -23,7 +23,7 @@
     <head>
         <title>Logout Page</title> 
         <style type="text/css">
-        body {background-color: #6C717C; font-family: Verdana; margin: 0; padding: 0; }
+        body { font-family: Verdana; margin: 0; padding: 0; }
         .perc-login-logo {color: #121212; margin-top: 160px; margin-bottom: 100px;}
         #loginform .perc-form    { }
         #perc-forgot {color: #fff;}

--- a/system/ear/jsps/unsupportedWarning.jsp
+++ b/system/ear/jsps/unsupportedWarning.jsp
@@ -14,7 +14,7 @@
     <head>
         <title>${rxcomp:i18ntext('jsp_unsupported@browser title',locale)}</title> 
         <style type="text/css">
-         body {background-color: #6C717C; font-family: Verdana; margin: 0; padding: 0; }
+         body { font-family: Verdana; margin: 0; padding: 0; }
         .perc-login-logo { font-size: 48px; color: #121212; margin-top: 160px; margin-bottom: 100px;}
         .perc-warning-message { width:400px; text-align:left;}
         .perc-warning-message a { color: #CCCCCC; text-decoration: none; font-weight: bold; }


### PR DESCRIPTION
This should get rid of any remaining pages that declare #6c717c as a body background.