### PR TITLE
Fix issue #1073 rxinline plugin causes Insert menu to fail to load.

### DIFF
--- a/modules/perc-tinymce/src/main/resources/META-INF/resources/sys_resources/tinymce/plugins/rxinline/plugin.js
+++ b/modules/perc-tinymce/src/main/resources/META-INF/resources/sys_resources/tinymce/plugins/rxinline/plugin.js
@@ -123,9 +123,9 @@ tinymce.PluginManager.add('rxinline', function(editor) {
         },
         onSetup: function (buttonApi) {
             if(isRXEditor() === false ){
-                buttonApi.hide();
+                buttonApi.setDisabled(true);
             }else{
-                buttonApi.show();
+                buttonApi.setDisabled(false);
             }
         },
         context: 'insert',


### PR DESCRIPTION
Fix plugin.  This was missed in 8.1.3.