### PR TITLE
Revert "Exclude External JS Links in Header while importing external templates and sites."

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/importer/theme/PSHTMLHeaderImporter.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/importer/theme/PSHTMLHeaderImporter.java
@@ -195,20 +195,13 @@ public class PSHTMLHeaderImporter
             {
                 // Add the paths into the map
                 String remoteUrl = urlConverter.getFullUrl(script.attr("src"));
-
+                
                 if(isNotBlank(remoteUrl))
                 {
-                    String fullThemePath;
-                    String convertedLink;
-                    //Don't change external Links while importing sites and templates
-                    if(!remoteUrl.startsWith(this.siteUrl)) {
-                        fullThemePath = remoteUrl;
-                        convertedLink = remoteUrl;
-                    }else {
-                        fullThemePath = urlConverter.getFileSystemPath(remoteUrl);
-                        convertedLink = urlConverter.convertToThemeLink(remoteUrl);
-                    }
+                    String fullThemePath = urlConverter.getFileSystemPath(remoteUrl);
                     scriptPaths.put(remoteUrl, fullThemePath);
+                    String convertedLink = urlConverter.convertToThemeLink(remoteUrl);
+                    
                     // Log the information related to the processed element
                     appendHeaderImporterMessage(MessageFormat.format(CONVERTED_SCRIPT_URL, script.attr("src"), convertedLink));
                     


### PR DESCRIPTION
Reverts percussion/percussioncms#1195.  Reverting as now no js files referenced by relative paths are getting imported.  The check needs to take into account if the url starts with a protocol or not, not just starts with the site url. 