### PR TITLE
Fix old support email address references.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This project, and everyone participating in it, is governed by the [Percussion C
 
 ## I just have a quick question...
 
-Questions can be posted on the [Community](https://github.com/percussion/percussioncms/discussions) discussion board.
+Questions can be posted on the [Community](https://percussioncmscommunity.intsof.com) discussion board.
 
 ## Getting Started
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,7 @@
 
 Percussion offers the following support channels:
 
-- For general problems, questions, how to, and other general issues use the [community site](https://github.com/percussion/percussioncms/discussions)
+- For general problems, questions, how to, and other general issues use the [community site](https://percussioncmscommunity.intsof.com)
 - To report bugs, defects, feature requests, or issues, please use this repository's
   [issue tracker](https://github.com/percussion/percussioncms/issues/new)
 

--- a/WebUI/war/app/includes/header.jsp
+++ b/WebUI/war/app/includes/header.jsp
@@ -108,7 +108,7 @@
                                                                              target="_blank" title="<i18n:message key="perc.ui.common.label@Help" />" rel="noopener noreferrer"><i18n:message key="perc.ui.common.label@Help"/></a> <%
         if (fullrolestr.contains("Admin")){
               %>| <a tabindex="3" role="button" href="/rest/api-docs?url=/rest/openapi.json&docExpansion=none&deepLinking=true&filter=true&tagsSorter=alpha" target="_blank" rel="noopener noreferrer" title="REST API Documentation">API</a>
-				<%}%>| <a tabindex="4" role="button" href="https://github.com/percussion/percussioncms/discussions/" target="_blank" rel="noopener noreferrer" title="<i18n:message key="perc.ui.common.label@Percussion Community"/>"><i18n:message key="perc.ui.common.label@Percussion Community"/></a>
+				<%}%>| <a tabindex="4" role="button" href="https://percussioncmscommunity.intsof.com/" target="_blank" rel="noopener noreferrer" title="<i18n:message key="perc.ui.common.label@Percussion Community"/>"><i18n:message key="perc.ui.common.label@Percussion Community"/></a>
 				| <a tabindex="5" role="button" href="javascript:void(0)" id="perc-help-about" title="<i18n:message key="perc.ui.common.label@About"/>"><i18n:message key="perc.ui.common.label@About"/></a>
 				| <a tabindex="6" role="button" href="/Rhythmyx/sys_cx/mainpage.html" id="perc-rhythmyx-ui"  title="<i18n:message key="perc.ui.common.label@Rhythmyx UI"/>"><i18n:message key="perc.ui.common.label@Rhythmyx UI"/></a>
 				| <a tabindex="7" role="button" href="/Rhythmyx/logout" title="<i18n:message key="perc.ui.common.label@Log Out"/>"><i18n:message key="perc.ui.common.label@Log Out"/></a>

--- a/WebUI/war/app/includes/minuetCommonTemplates/navigationTemplates.jsp
+++ b/WebUI/war/app/includes/minuetCommonTemplates/navigationTemplates.jsp
@@ -104,7 +104,7 @@
             </div>
             <div class="row">
                 <div class="col">
-                    <a tabindex="0" role="button" href="https://github.com/percussion/percussioncms/discussions/" target="_blank" rel="noopener noreferrer" title="<i18n:message key="perc.ui.common.label@Percussion Community" />" role="button" class="btn btn-block perc-btn-inverse perc-nav-menu-button text-left">
+                    <a tabindex="0" role="button" href="https://percussioncmscommunity.intsof.com/" target="_blank" rel="noopener noreferrer" title="<i18n:message key="perc.ui.common.label@Percussion Community" />" role="button" class="btn btn-block perc-btn-inverse perc-nav-menu-button text-left">
                   <span>
                     <i aria-hidden class="fas fa-hands-helping fa-fw"></i>
                   </span>

--- a/WebUI/war/gadgets/repository/common/css/PercDataTable.css
+++ b/WebUI/war/gadgets/repository/common/css/PercDataTable.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/WebUI/war/gadgets/repository/common/css/PercSimpleMenu.css
+++ b/WebUI/war/gadgets/repository/common/css/PercSimpleMenu.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/WebUI/war/gadgets/repository/common/perc_common_gadget.css
+++ b/WebUI/war/gadgets/repository/common/perc_common_gadget.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/WebUI/war/plugins/PercImportProgressDialog.js
+++ b/WebUI/war/plugins/PercImportProgressDialog.js
@@ -142,7 +142,7 @@
 
              dialogMarkup.append(
                 $('<div>')
-                    .append('<p class="hint">Ask questions. Get answers. Visit the <a target="_blank" rel = "noopener noreferrer" href="https://github.com/percussion/percussioncms/discussions" title="Percussion Community">Percussion Community</a> to access Video Tutorials, Forums, and more.</p>')
+                    .append('<p class="hint">Ask questions. Get answers. Visit the <a target="_blank" rel = "noopener noreferrer" href="https://percussioncmscommunity.intsof.com" title="Percussion Community">Percussion Community</a> to access Video Tutorials, Forums, and more.</p>')
             );
 
             if (config.showVideo === true)

--- a/WebUI/war/views/PercTemplateView.js
+++ b/WebUI/war/views/PercTemplateView.js
@@ -206,7 +206,7 @@
                     percDropdownCallbacks    : [function(){}, function(){viewImportLog()},
                         function(){openUrl("UIVideo", "https://percussioncmshelp.intsof.com/percussion-cm1/overview/introduction-to-the-ui")},
                         function(){openUrl("ImportFAQs", "https://percussioncmshelp.intsof.com/in-product/import-faqs")},
-                        function(){openUrl("PercussionCommunity", "https://github.com/percussion/percussioncms/discussions")},
+                        function(){openUrl("PercussionCommunity", "https://percussioncmscommunity.intsof.com")},
                         function(){openUrl("MoreHelp", "https://percussioncmshelp.intsof.com")}],
                     percDropdownCallbackData : [I18N.message("perc.ui.template.design.view@Help"),I18N.message("perc.ui.template.design.view@Download Report Log"), I18N.message("perc.ui.template.design.view@Video Tutorials"), I18N.message("perc.ui.template.design.view@Import FAQs"), I18N.message("perc.ui.template.design.view@Percussion Community"), I18N.message("perc.ui.template.design.view@More Help")],
                     percDropdownDisabledFlag : disableActionsHelp

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat9/webapps/ROOT/index.html
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat9/webapps/ROOT/index.html
@@ -18,7 +18,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/deployer/schema/localConfig.xsd
+++ b/deployer/schema/localConfig.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/modules/utils/src/main/resources/com/percussion/install/RxInstaller.properties
+++ b/modules/utils/src/main/resources/com/percussion/install/RxInstaller.properties
@@ -282,8 +282,8 @@ ftpDeliveryTypes="ftp" and/or "sftp" delivery types were found.  Please see {Per
 
 #Questions or concerns
 docHelp=For questions or concerns, please reference the Percussion document, or contact:
-northAmericaSupport=North America Support \n 9:00 AM to 6:00 PM ET, Monday-Friday \n Phone: 800.283.0800 \n Fax: 781.438.9955 \n Email: technical_support@percussion.com
-europeSupport=Europe Support \n 8:30 AM to 6:00 PM UK, Monday - Friday \n Phone: (+44) (0) 207.334.5900 \n Fax: (+44) (0) 207.437.5940 \n Email: technical_support_UK@percussion.com
+northAmericaSupport=North America Support \n 9:00 AM to 6:00 PM ET, Monday-Friday \n Phone: +1-443-535-1889 \n Fax: 781.438.9955 \n Email: percussion.support@intsof.com
+europeSupport=Europe Support \n 8:30 AM to 6:00 PM UK, Monday - Friday \n Phone: (+44) (0) 207.334.5900 \n Fax: (+44) (0) 207.437.5940 \n Email: percussion.support@intsof.com
 
 #Currently Installed Products
 currInstProds=The following currently installed products were not selected, but will be upgraded:

--- a/projects/sitemanage/src/test/resources/contentmigration/sourceDoc.html
+++ b/projects/sitemanage/src/test/resources/contentmigration/sourceDoc.html
@@ -18,7 +18,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/contentmigration/targetDoc.html
+++ b/projects/sitemanage/src/test/resources/contentmigration/targetDoc.html
@@ -18,7 +18,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/importer/CM1905-SamplePage.html
+++ b/projects/sitemanage/src/test/resources/importer/CM1905-SamplePage.html
@@ -18,7 +18,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/importer/data/rx_resources/default_theme/theme.css
+++ b/projects/sitemanage/src/test/resources/importer/data/rx_resources/default_theme/theme.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/importer/importA.css
+++ b/projects/sitemanage/src/test/resources/importer/importA.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/importer/importB.css
+++ b/projects/sitemanage/src/test/resources/importer/importB.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/importer/sample_backup.css
+++ b/projects/sitemanage/src/test/resources/importer/sample_backup.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/service/SiteSuckerReport.html
+++ b/projects/sitemanage/src/test/resources/service/SiteSuckerReport.html
@@ -18,7 +18,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/themes.tmp/pssessionid/16777215-101-618.css
+++ b/projects/sitemanage/src/test/resources/themes.tmp/pssessionid/16777215-101-618.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/themes/more-than-one-css/more-than-one-css.css
+++ b/projects/sitemanage/src/test/resources/themes/more-than-one-css/more-than-one-css.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/themes/more-than-one-css/perc/perc_region.css
+++ b/projects/sitemanage/src/test/resources/themes/more-than-one-css/perc/perc_region.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/themes/more-than-one-css/theme-1.css
+++ b/projects/sitemanage/src/test/resources/themes/more-than-one-css/theme-1.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/themes/more-than-one-css/theme-2.css
+++ b/projects/sitemanage/src/test/resources/themes/more-than-one-css/theme-2.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/themes/more-than-one-thumb-images/perc/perc_region.css
+++ b/projects/sitemanage/src/test/resources/themes/more-than-one-thumb-images/perc/perc_region.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/themes/more-than-one-thumb-images/perc_theme.css
+++ b/projects/sitemanage/src/test/resources/themes/more-than-one-thumb-images/perc_theme.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/themes/no-thumb-image/perc_theme.css
+++ b/projects/sitemanage/src/test/resources/themes/no-thumb-image/perc_theme.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/themes/test/perc/perc_region.css
+++ b/projects/sitemanage/src/test/resources/themes/test/perc/perc_region.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/projects/sitemanage/src/test/resources/themes/test/perc_theme.css
+++ b/projects/sitemanage/src/test/resources/themes/test/perc_theme.css
@@ -18,7 +18,7 @@
  *      PO Box 767
  *      Burlington, MA 01803, USA
  *      +01-781-438-9900
- *      support@percussion.com
+ *      percussion.support@intsof.com
  *      https://www.percussion.com
  *
  *     You should have received a copy of the GNU General Public License

--- a/system/Docs/Server_Administrator/Copyrights_and_Trademarks.htm
+++ b/system/Docs/Server_Administrator/Copyrights_and_Trademarks.htm
@@ -37,7 +37,7 @@
 <p class="bodytext">AuthorIT&#8482; is a trademark of Optical Systems Corporation Ltd.</p>
 <p class="bodytext">Microsoft Word, Microsoft Office, Windows&reg;, Window 95&#8482;, Window 98&#8482;, Windows NT&reg;and MS-DOS&#8482; are trademarks of the Microsoft Corporation.</p>
 <p class="bodytext">This document was created using <a class="jumptemplate" title="AuthorIT Home" href="http://www.author-it.com" target="_self">AuthorIT&#8482;, Total Document Creation</a>.</p>
-<p class="bodytext"><strong class="specialbold">Percussion Software</strong><br>600 Unicorn Park Drive<br>Woburn, MA 01801 U.S.A.<br>781.438.9900<br>Internet E-Mail: technical_support@percussion.com<br>Website: http://www.percussion.com</p>
+<p class="bodytext"><strong class="specialbold">Percussion Software</strong><br>600 Unicorn Park Drive<br>Woburn, MA 01801 U.S.A.<br>781.438.9900<br>Internet E-Mail: percussion.support@intsof.com<br>Website: http://www.percussion.com</p>
 
 </body>
 </html>

--- a/system/Docs/Server_Administrator/Topics/Copyrights_and_Trademarks.htm
+++ b/system/Docs/Server_Administrator/Topics/Copyrights_and_Trademarks.htm
@@ -37,7 +37,7 @@
 <p class="bodytext">AuthorIT&#8482; is a trademark of Optical Systems Corporation Ltd.</p>
 <p class="bodytext">Microsoft Word, Microsoft Office, Windows&reg;, Window 95&#8482;, Window 98&#8482;, Windows NT&reg;and MS-DOS&#8482; are trademarks of the Microsoft Corporation.</p>
 <p class="bodytext">This document was created using <a class="jumptemplate" title="AuthorIT Home" href="http://www.author-it.com" target="_self">AuthorIT&#8482;, Total Document Creation</a>.</p>
-<p class="bodytext"><strong class="specialbold">Percussion Software</strong><br>600 Unicorn Park Drive<br>Woburn, MA 01801 U.S.A.<br>781.438.9900<br>Internet E-Mail: technical_support@percussion.com<br>Website: http://www.percussion.com</p>
+<p class="bodytext"><strong class="specialbold">Percussion Software</strong><br>600 Unicorn Park Drive<br>Woburn, MA 01801 U.S.A.<br>781.438.9900<br>Internet E-Mail: percussion.support@intsof.com<br>Website: http://www.percussion.com</p>
 
 </body>
 </html>

--- a/system/Packages/perc.gadget.welcome/sys__UserDependency--cm/gadgets/repository/cm1_welcome_gadget/perc_welcome_gadget.xml
+++ b/system/Packages/perc.gadget.welcome/sys__UserDependency--cm/gadgets/repository/cm1_welcome_gadget/perc_welcome_gadget.xml
@@ -43,7 +43,7 @@
           <a class="perc-gadget-welcome-link" id="perc-gadget-welcome-link-1" href="https://percussioncmshelp.intsof.com" target="_blank" rel="noopener noreferrer" title="Documentation">Documentation</a><br/>
           <span class="perc-gadget-welcome-link-desc" id="perc-gadget-welcome-link-2">All the basics on creating and maintaining your website(s) with Percussion CMS.</span><br/>
           <div class="perc-gadget-separator"><div class="perc-gadget-separator-inner"></div></div>
-          <a class="perc-gadget-welcome-link" id="perc-gadget-welcome-link-3" href="https://github.com/percussion/percussioncms/discussions" target="_blank" rel="noopener noreferrer" title="Percussion Community">Percussion Community</a><br/>
+          <a class="perc-gadget-welcome-link" id="perc-gadget-welcome-link-3" href="https://percussioncmscommunity.intsof.com" target="_blank" rel="noopener noreferrer" title="Percussion Community">Percussion Community</a><br/>
           <span class="perc-gadget-welcome-link-desc" id="perc-gadget-welcome-link-4">Ask questions and discuss ideas with fellow Percussion CMS users.</span><br/>
           <div class="perc-gadget-separator"><div class="perc-gadget-separator-inner"></div></div>
 		  <div id="perc-bookmark-container">

--- a/system/Testing/applications/rx_ceCataloger/ApplicationFiles/rxcx1030_CATALOGER.dtd
+++ b/system/Testing/applications/rx_ceCataloger/ApplicationFiles/rxcx1030_CATALOGER.dtd
@@ -19,7 +19,7 @@
   -      PO Box 767
   -      Burlington, MA 01803, USA
   -      +01-781-438-9900
-  -      support@percussion.com
+  -      percussion.support@intsof.com
   -      https://www.percussion.com
   -
   -     You should have received a copy of the GNU General Public License

--- a/system/agenthandler/applications/sys_ageSupport/ApplicationFiles/agecontentlist.dtd
+++ b/system/agenthandler/applications/sys_ageSupport/ApplicationFiles/agecontentlist.dtd
@@ -19,7 +19,7 @@
   -      PO Box 767
   -      Burlington, MA 01803, USA
   -      +01-781-438-9900
-  -      support@percussion.com
+  -      percussion.support@intsof.com
   -      https://www.percussion.com
   -
   -     You should have received a copy of the GNU General Public License

--- a/system/cms/content/applications/sys_resources/ApplicationFiles/i18n/CmsUi.tmx
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/i18n/CmsUi.tmx
@@ -1300,10 +1300,10 @@
         <tu tuid="perc.ui.publish.errordialog.message@Publish Not Allowed">
             <note xml:lang="en-us">Message for publication stopped for licensing issues.</note>
             <tuv xml:lang="en-us">
-                <seg>You have either exceeded your license limits or have an inactive license and simply need to register. Please return to the License Monitor on the Dashboard to resolve this issue. To upgrade your license contact a sales rep at sales@percussion.com or 800.283.0800. Thank you. </seg>
+                <seg>You have either exceeded your license limits or have an inactive license and simply need to register. Please return to the License Monitor on the Dashboard to resolve this issue. To upgrade your license contact a sales rep at sales@percussion.com or +1-443-535-1889. Thank you. </seg>
             </tuv>
             <tuv xml:lang="es">
-                <seg>Usted ha excedido los límites de su licencia o tiene una licencia inactiva y simplemente necesita registrarse. Vuelva al Monitor de licencia en el panel de control para resolver este problema. Para actualizar su licencia, póngase en contacto con un representante de ventas en sales@percussion.com o 01+800.283.0800. Gracias. </seg>
+                <seg>Usted ha excedido los límites de su licencia o tiene una licencia inactiva y simplemente necesita registrarse. Vuelva al Monitor de licencia en el panel de control para resolver este problema. Para actualizar su licencia, póngase en contacto con un representante de ventas en sales@percussion.com o 01++1-443-535-1889. Gracias. </seg>
             </tuv>
         </tu>
         <tu tuid="perc.ui.publish.errordialog.message@Bad configuration">
@@ -5889,10 +5889,10 @@ Documentación' href='https://percussioncmshelp.intsof.com/'&gt;percussioncmshel
                     <prop type="sectionname" xml:lang="en-us">License Monitor Gadget</prop>
                     <note xml:lang="en-us"></note>
                     <tuv xml:lang="en-us">
-                        <seg>Input the activation code sent to you by Percussion. If you have not received an activation code, please check your email or call us at 800.283.0800 for assistance.</seg>
+                        <seg>Input the activation code sent to you by Percussion. If you have not received an activation code, please check your email or call us at +1-443-535-1889 for assistance.</seg>
                     </tuv>
                     <tuv xml:lang="es">
-                        <seg>Ingrese el código de activación que le envió Percussion. Si no ha recibido un código de activación, revise su correo electrónico o llámenos al 800.283.0800 para obtener ayuda.</seg>
+                        <seg>Ingrese el código de activación que le envió Percussion. Si no ha recibido un código de activación, revise su correo electrónico o llámenos al +1-443-535-1889 para obtener ayuda.</seg>
                     </tuv>
      </tu>
      <tu tuid="perc.ui.gadgets.licenseMonitor@Activation code">
@@ -5929,10 +5929,10 @@ Documentación' href='https://percussioncmshelp.intsof.com/'&gt;percussioncmshel
                     <prop type="sectionname" xml:lang="en-us">License Monitor Gadget</prop>
                     <note xml:lang="en-us"></note>
                     <tuv xml:lang="en-us">
-                        <seg>Below is a list of activated Percussion modules. To activate a module, input the activation code(s) sent to you by Percussion.  If you have not received an activation code, please check your email or call us at 800.283.0800 for assistance. If a module is displayed as inactive you can enter in a new activation code to update that particular module.</seg>
+                        <seg>Below is a list of activated Percussion modules. To activate a module, input the activation code(s) sent to you by Percussion.  If you have not received an activation code, please check your email or call us at +1-443-535-1889 for assistance. If a module is displayed as inactive you can enter in a new activation code to update that particular module.</seg>
                     </tuv>
                     <tuv xml:lang="es">
-                        <seg>A continuación se muestra una lista de módulos de Percussion activados. Para activar un módulo, ingrese los códigos de activación que le envió Percussion. Si no ha recibido un código de activación, revise su correo electrónico o llámenos al 800.283.0800 para obtener ayuda. Si un módulo se muestra como inactivo, puede ingresar un nuevo código de activación para actualizar ese módulo en particular.</seg>
+                        <seg>A continuación se muestra una lista de módulos de Percussion activados. Para activar un módulo, ingrese los códigos de activación que le envió Percussion. Si no ha recibido un código de activación, revise su correo electrónico o llámenos al +1-443-535-1889 para obtener ayuda. Si un módulo se muestra como inactivo, puede ingresar un nuevo código de activación para actualizar ese módulo en particular.</seg>
                     </tuv>
      </tu>
      <tu tuid="perc.ui.gadgets.licenseMonitor@Close">
@@ -6019,10 +6019,10 @@ Documentación' href='https://percussioncmshelp.intsof.com/'&gt;percussioncmshel
                     <prop type="sectionname" xml:lang="en-us">License Monitor Gadget</prop>
                     <note xml:lang="en-us"></note>
                     <tuv xml:lang="en-us">
-                        <seg>You have exceeded your license limits. To get within allowed limits you may delete or archive live pages or sites and refresh. If your license has been suspended, you will not be able to publish. To remove the suspension, contact Percussion at sales@percussion.com or 800.283.0800.</seg>
+                        <seg>You have exceeded your license limits. To get within allowed limits you may delete or archive live pages or sites and refresh. If your license has been suspended, you will not be able to publish. To remove the suspension, contact Percussion at sales@percussion.com or +1-443-535-1889.</seg>
                     </tuv>
                     <tuv xml:lang="es">
-                        <seg>Ha excedido los límites de su licencia. Para estar dentro de los límites permitidos, puede eliminar o archivar páginas o sitios en vivo y actualizar. Si su licencia ha sido suspendida, no podrá publicar. Para eliminar la suspensión, comuníquese con Percussion a sales@percussion.com o al 800.283.0800.</seg>
+                        <seg>Ha excedido los límites de su licencia. Para estar dentro de los límites permitidos, puede eliminar o archivar páginas o sitios en vivo y actualizar. Si su licencia ha sido suspendida, no podrá publicar. Para eliminar la suspensión, comuníquese con Percussion a sales@percussion.com o al +1-443-535-1889.</seg>
                     </tuv>
      </tu>
      <tu tuid="perc.ui.gadgets.licenseMonitor@Refresh">

--- a/system/ear/jsps/unsupportedWarning.jsp
+++ b/system/ear/jsps/unsupportedWarning.jsp
@@ -45,7 +45,7 @@
                         <div class='perc-login-logo'><img src="sys_resources/images/percussion-logo.png" alt="${rxcomp:i18ntext('general@Percussion Logo Alt',locale)}" title="${rxcomp:i18ntext('general@Percussion Logo Title',locale)}"/></div>   
                   		<p class = "perc-warning-message">${rxcomp:i18ntext('jsp_unsupported@warning message part1',locale)}</p><p class = "perc-warning-message">${rxcomp:i18ntext('jsp_unsupported@warning message part2',locale)}<p>
 						<p class="perc-warning-message">
-						${rxcomp:i18ntext('jsp_unsupported@warning message part3',locale)} <a href="mailto:support@percussion.com">${rxcomp:i18ntext('jsp_unsupported@the technical support team',locale)}.</a></p>
+						${rxcomp:i18ntext('jsp_unsupported@warning message part3',locale)} <a href="mailto:percussion.support@intsof.com">${rxcomp:i18ntext('jsp_unsupported@the technical support team',locale)}.</a></p>
 						<p class = "perc-warning-message">${rxcomp:i18ntext('jsp_unsupported@warning message part4',locale)} <a href="${rxcomp:i18ntext('jsp_unsupported@supported browser link',locale)}" target="_blank" rel = "noopener noreferrer" title="${rxcomp:i18ntext('jsp_unsupported@supported browser link title',locale)}">${rxcomp:i18ntext('jsp_unsupported@supported browser link text',locale)}</a>.</p>
                     </div>
                 </td>

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/BasicObjects.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/BasicObjects.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/ContentEditorLocalDef.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/ContentEditorLocalDef.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/ContentEditorSharedDef.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/ContentEditorSharedDef.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/ContentEditorSystemDef.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/ContentEditorSystemDef.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/assembly.wsdl
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/assembly.wsdl
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/assembly.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/assembly.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/assemblyServices.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/assemblyServices.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/common.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/common.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/content.wsdl
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/content.wsdl
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/content.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/content.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/contentServices.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/contentServices.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/faults.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/faults.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/rhythmyx.wsdl
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/rhythmyx.wsdl
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/security.wsdl
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/security.wsdl
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/security.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/security.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/securityServices.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/securityServices.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/system.wsdl
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/system.wsdl
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/system.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/system.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/systemServices.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/systemServices.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/ui.wsdl
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/ui.wsdl
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/ui.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/ui.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License

--- a/system/webservices/test/CS/RxTest/Web References/RxWebServices/uiServices.xsd
+++ b/system/webservices/test/CS/RxTest/Web References/RxWebServices/uiServices.xsd
@@ -19,7 +19,7 @@
   ~      PO Box 767
   ~      Burlington, MA 01803, USA
   ~      +01-781-438-9900
-  ~      support@percussion.com
+  ~      percussion.support@intsof.com
   ~      https://www.percussion.com
   ~
   ~     You should have received a copy of the GNU General Public License


### PR DESCRIPTION
Replace all references to support@percussion.com, technical_support@percussion.com, technical_support_UK@percussion.com with percussion.support@intsof.com.  Replace github discussions with percussioncmscommunity.intsof.com link.