### PR TITLE
 jvm.ini in jetty/base/start.d is throwing an error related to "xalan…

### DIFF
--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/updateConfiguration.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/updateConfiguration.xml
@@ -232,6 +232,10 @@
             <available file="${install.dir}/jetty/base/start.d/jvm.ini"/>
             <then>
                 <replace file="${install.dir}/jetty/base/start.d/jvm.ini" token="@@rxdir@@" value="${normalized.install.dir}" />
+                <replace file="${install.dir}/jetty/base/start.d/jvm.ini" token="-Djavax.xml.transform.TransformerFactory" value="#-Djavax.xml.transform.TransformerFactory" />
+                <replace file="${install.dir}/jetty/base/start.d/jvm.ini" token="-Djavax.xml.parsers.SAXParserFactory" value="#-Djavax.xml.parsers.SAXParserFactory" />
+                <replace file="${install.dir}/jetty/base/start.d/jvm.ini" token="-Djavax.xml.datatype.DatatypeFactory" value="#-Djavax.xml.datatype.DatatypeFactory" />
+                <replace file="${install.dir}/jetty/base/start.d/jvm.ini" token="-Djavax.xml.parsers.DocumentBuilderFactory" value="#-Djavax.xml.parsers.DocumentBuilderFactory" />
             </then>
         </if>
         <replace file="${install.dir}/PercussionXMLCatalog.xml" token="@@rxdir@@" value="${lead.slash}${normalized.install.dir}" />


### PR DESCRIPTION
…" in case of upgrading the CMS version #1148